### PR TITLE
Improve finitely presented semigroups

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,6 +123,8 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+#Forces order of functions to appear as in source code, rather than sorted.
+autodoc_member_order = 'bysource'
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/semigroups/elements.py
+++ b/semigroups/elements.py
@@ -6,7 +6,6 @@ This module contains classes for representing elements of semigroups.
 
 import libsemigroups
 
-
 class Transformation(libsemigroups.TransformationNC):
     '''
     A class for handling libsemigroups transformations.
@@ -512,3 +511,4 @@ class PBR(libsemigroups.PBRNC):
                     self.__neg_out_neighbours.append(sorted(copy))
         return ('PBR(%s, %s)'
                 % (self.__pos_out_neighbours, self.__neg_out_neighbours))
+

--- a/semigroups/libsemigroups.pyx
+++ b/semigroups/libsemigroups.pyx
@@ -152,7 +152,6 @@ cdef class ElementABC:
         identity[0].really_delete()
         return out
 
-
 cdef class TransformationNC(ElementABC):
     def __init__(self, images):
         self._handle = new libsemigroups.Transformation[uint16_t](images)
@@ -477,9 +476,7 @@ cdef class SemigroupNC:
                 yield self.new_from_handle(element)
             pos += 1
 
-
-# FIXME should be a subclass of SemigroupNC
-cdef class FpSemigroupNC:
+cdef class FpSemigroupNC(SemigroupNC):
     cdef libsemigroups.Congruence* _congruence
     cdef libsemigroups.RWS* _rws
     
@@ -511,10 +508,11 @@ cdef class FpSemigroupNC:
 
     def set_report(self, val):
         '''
-        toggles whether or not to report data when running certain functions
+        Sets whether or not to report data when running certain 
+        functions (e.g size).
 
         Args:
-            bool:toggle to True or False
+            bool:set to True or False
         '''
         if val != True and val != False:
             raise TypeError('the argument must be True or False')
@@ -525,7 +523,7 @@ cdef class FpSemigroupNC:
 
     def set_max_threads(self, nr_threads):
         '''
-        sets the maximum number of threads to be used at once.
+        Sets the maximum number of threads to be used at once.
 
         Args:
             int:number of threads
@@ -534,14 +532,23 @@ cdef class FpSemigroupNC:
 
     def is_confluent(self):
         '''
-        check if the relations of the FpSemigroup are confluent.
+        Checks if the rewriting system defined by the relations of a finitely 
+        presented semigroup is confluent.
+        
+        If a finitely presented semigroup has a confluent rewriting system
+        then it has solvable word problem. In other words, there is an 
+        algorithm to decide when two words over the generators of the semigroup
+        are equal. Indeed, once we have a confluent rewriting system, it is
+        possible to successfully test that two words represent the same element
+        in the semigroup, by reducing both words using the rewriting system
+        rules.
 
         Examples:
-            >>> FpSemigroup(["a","b"],[["aa","a"],["bbb","ab"],
-                                                  ["ab","ba"]).is_confluent()
+            >>> FpSemigroup("ab",[["aa","a"],["bbb","ab"],
+                                             ["ab","ba"]).is_confluent()
             True
-            >>> FpSemigroup(["a","b"],[["aa","a"],["bab","ab"],
-                                                  ["ab","ba"]).is_confluent()
+            >>> FpSemigroup("ab",[["aa","a"],["bab","ab"],
+                                             ["ab","ba"]).is_confluent()
             False
 
         Returns:

--- a/semigroups/libsemigroups_cpp.h
+++ b/semigroups/libsemigroups_cpp.h
@@ -64,9 +64,16 @@ namespace libsemigroups {
     }
 
     void redefine(Element const* x, Element const* y) override {
-      PyObject* product
+      PyObject* product;
+      if (static_cast<const PythonElement*>(x)->_value == Py_None) {
+        product = static_cast<const PythonElement*>(y)->_value;
+      } else if (static_cast<const PythonElement*>(y)->_value == Py_None) {
+        product = static_cast<const PythonElement*>(x)->_value;
+      } else {
+        product
           = PyNumber_Multiply(static_cast<const PythonElement*>(x)->_value,
                               static_cast<const PythonElement*>(y)->_value);
+      }
       Py_DECREF(_value);
       _value = product;
       Py_INCREF(_value);

--- a/semigroups/semifp.py
+++ b/semigroups/semifp.py
@@ -1,9 +1,13 @@
+'''
+This module contains the classes FpSemigroup and FpMonoid.
+'''
+# pylint: disable = no-member, len-as-condition
 import libsemigroups
-
 
 class FpSemigroup(libsemigroups.FpSemigroupNC):
     '''
-    A class for finitely presented semigroups.
+    A *finitely presented semigroup* is a quotient of a free semigroup on
+    a finite number of generators by a finitely generated congruence.
 
     Args:
         alphabet (string): the generators of the finitely presented semigroup,
@@ -13,9 +17,12 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             equivalent in the finitely presented semigroup
 
     Raises:
-        TypeError: if TODO
+        TypeError: if the first argument is not a string or the second
+                   argument is not a list of pairs of strings.
 
-        ValueError: if TODO
+        ValueError: if the first arugment contains duplicates or the relations
+                    in the second argument reference a character not in the
+                    alphabet.
 
     Examples:
         >>> FpSemigroup('ab',
@@ -41,11 +48,138 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
                                  + ' does not belong to the alphabet %s'
                                  % self.alphabet)
 
+    def __remove_brackets(self, word):
+        # pylint: disable = too-many-branches
+        if word == '':
+            return ''
+
+        #if the number of left brackets is different from the number of right
+        #brackets they can't possibly pair up
+        if not word.count('(') == word.count(')'):
+            raise ValueError('unmatched bracket')
+
+        #if the ^ is at the end of the string there is no exponent.
+        #if the ^ is at the start of the string there is no base.
+        if word[0] == '^' or word[-1] == '^':
+            raise ValueError('invalid power structure')
+
+        #checks that all ^s have an exponent.
+        for index, element in enumerate(word):
+            if element == '^':
+                if not word[index + 1] in '0123456789':
+                    raise ValueError('invalid power structure')
+
+        #i acts as a pointer to positions in the string.
+        newword = ''
+        i = 0
+        while i < len(word):
+            #if there are no brackets the character is left as it is.
+            if word[i] != '(':
+                newword += word[i]
+            else:
+                lbracket = i
+                rbracket = -1
+                #tracks how 'deep' the position of i is in terms of nested
+                #brackets
+                nestcount = 0
+                i += 1
+                while i < len(word):
+                    if word[i] == '(':
+                        nestcount += 1
+                    elif word[i] == ')':
+                        if nestcount == 0:
+                            rbracket = i
+                            break
+                        else:
+                            nestcount -= 1
+                    i += 1
+
+                #as i is always positive, if rbracket is -1 that means that
+                #the found left bracket has no corresponding right bracket.
+                #note: if this never occurs then every left bracket has a
+                #corresponding right bracket and as the number of each bracket
+                #is equal every right bracket has a corresponding left bracket
+                #and the bracket structure is valid.
+                if rbracket == -1:
+                    raise ValueError('unmatched bracket')
+
+                #if rbracket is not followed by ^ then the value inside the
+                #bracket is appended (recursion is used to remove any brackets
+                #in this value)
+                if rbracket + 1 == len(word):
+                    newword += self.__remove_brackets(word[lbracket + 1:
+                                                           rbracket])
+                elif word[rbracket + 1] != '^':
+                    newword += self.__remove_brackets(word[lbracket + 1:
+                                                           rbracket])
+                #if rbracket is followed by ^ then the value inside the
+                #bracket is appended the given number of times
+                else:
+                    i += 2
+                    while i < len(word):
+                        if word[i] in '0123456789':
+                            i += 1
+                        else:
+                            break
+                    newword += (self.__remove_brackets(word[lbracket + 1:
+                                                            rbracket])
+                                * int(word[rbracket + 2:i]))
+                    i -= 1
+            i += 1
+
+        return newword
+
+    @staticmethod
+    def __remove_powers(word):
+        if word == '':
+            return ''
+
+        #if the ^ is at the end of the string there is no exponent.
+        #if the ^ is at the start of the string there is no base.
+        if word[0] == '^' or word[-1] == '^':
+            raise ValueError('invalid power structure')
+
+        #checks that all ^s have an exponent.
+        for index, element in enumerate(word):
+            if element == '^':
+                if not word[index + 1] in '0123456789':
+                    raise ValueError('invalid power structure')
+
+        newword = ''
+        i = 0
+        while i < len(word):
+            #if last character reached there is no space for exponentiation.
+            if i == len(word) - 1:
+                newword += word[i]
+                i += 1
+            #if the character is not being powered then it is left as it is.
+            elif word[i + 1] != '^':
+                newword += word[i]
+                i += 1
+            else:
+                base_position = i
+                i += 2
+                if i < len(word):
+                    #extracts the exponent from the string.
+                    while word[i] in '0123456789':
+                        i += 1
+                        if i >= len(word):
+                            break
+                newword += (word[base_position] *
+                            int(word[base_position + 2:i]))
+        return newword
+
+    def __remove_powers_and_brackets(self, word):
+        '''
+        Removes ^ and () from a given word.
+        '''
+        return self.__remove_powers(self.__remove_brackets(word))
+
     def __init__(self, alphabet, rels):
         # Check the alphabet
         if not isinstance(alphabet, str):
             raise TypeError('the first argument (alphabet) must be a string')
-        elif not all(alphabet.count(x) == 1 for x in alphabet):
+        elif not all(alphabet.count(i) == 1 for i in alphabet):
             raise ValueError('the first argument (alphabet) must be a '
                              'duplicate-free string')
 
@@ -63,7 +197,18 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             raise TypeError('the second argument (relations) must be a ' +
                             'list of pairs of strings')
 
-        # TODO parse relations using ^ etc here, as per in ParseRelators in GAP
+        pure_letter_alphabet = True
+        for i in alphabet:
+            if not i in ('abcdefghijklmnopqrstuvwxyz1' +
+                         'ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
+                pure_letter_alphabet = False
+                break
+
+        if pure_letter_alphabet:
+            for i, rel in enumerate(rels):
+                for j, word in enumerate(rel):
+                    rels[i][j] = self.__remove_powers_and_brackets(word)
+
         self.alphabet = alphabet
         self.relations = rels
 
@@ -74,11 +219,13 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
         libsemigroups.FpSemigroupNC.__init__(self, len(alphabet), rels)
 
     def __repr__(self):
-        return ("<fp semigroup with %d generators and %d relations>"
+        return ('<fp semigroup with %d generators and %d relations>'
                 % (len(self.alphabet), len(self.relations)))
 
     def size(self):
-        '''Attempt to compute the size of the finitely presented semigroup.
+        '''
+        Attempts to compute the number of elements of the finitely
+        presented semigroup.
 
         Returns:
             int: the size of the finitely presented semigroup.
@@ -129,11 +276,13 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             if not stop:
                 return False
 
-        return (isinstance(libsemigroups.FpSemigroupNC.size(self), int) or
-                isinstance(libsemigroups.FpSemigroupNC.size(self), long))
+        return isinstance(libsemigroups.FpSemigroupNC.size(self), int)
 
     def word_to_class_index(self, word):
         '''Returns the class index of a given word.
+
+        The class index of a word is a number used to represent the set
+        of words equivalent to that word in the semigroup.
 
         Args:
             word (str): word whose class index is to be returned.
@@ -142,8 +291,9 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             int: class index of the given word.
 
         Raises:
-            TypeError: if TODO
-            ValueError: if TODO
+            TypeError: if the argument is not a string.
+            ValueError: if the argument contains a character not in the
+                        alphabet of the FpSemigroup.
 
         Examples:
             >>> S = FpSemigroup('ab',
@@ -153,16 +303,38 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             >>> S.word_to_class_index('b')
             1
         '''
-
         self.__check_word(word)
         return libsemigroups.FpSemigroupNC.word_to_class_index(self, word)
 
 
 class FpMonoid(FpSemigroup):
+    '''
+    A *finitely presented monoid* is a quotient of a free monoid on a
+    finite number of generators over a finitely generated congruence
+    on the free monoid.
+
+    Args:
+        alphabet (string): the generators of the finitely presented semigroup,
+            must be a string of distinct characters.
+
+        rels (list): the relations containing pairs of string which are
+            equivalent in the finitely presented semigroup
+
+    Raises:
+        TypeError: if the first argument is not a string or the second
+                   argument is not a list of pairs of strings.
+
+        ValueError: if the first arugment contains duplicates, if the first
+                    argument contains a 1 or if the relations in the second
+                    argument reference a character not in the alphabet.
+
+    Examples:
+        >>> FpMonoid('ab',
+        ...             [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']])
+        <fp monoid with 2 generators and 3 relations>
+    '''
+
     def __init__(self, alphabet, rels):
-        '''
-        Construct a finitely presented monoid from generators and relations.
-        '''
         if '1' in alphabet:
             raise ValueError('the first argument (alphabet) must '
                              + 'not contain 1')
@@ -177,5 +349,5 @@ class FpMonoid(FpSemigroup):
     def __repr__(self):
         nrgens = len(self.alphabet) - 1
         nrrels = len(self.relations) - 2 * nrgens - 1
-        return ("<fp monoid with %d generators and %d relations>"
+        return ('<fp monoid with %d generators and %d relations>'
                 % (nrgens, nrrels))

--- a/semigroups/semifp.py
+++ b/semigroups/semifp.py
@@ -1,10 +1,11 @@
 '''
 This module contains the classes FpSemigroup and FpMonoid.
 '''
-# pylint: disable = no-member, len-as-condition
+# pylint: disable = no-member, len-as-condition, invalid-name
 import libsemigroups
+from semigroups.semigrp import Semigroup
 
-class FpSemigroup(libsemigroups.FpSemigroupNC):
+class FpSemigroup(libsemigroups.FpSemigroupNC, Semigroup):
     '''
     A *finitely presented semigroup* is a quotient of a free semigroup on
     a finite number of generators by a finitely generated congruence.
@@ -30,151 +31,8 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
         <fp semigroup with 2 generators and 3 relations>
 
     TODO:
-         write == method
-         write normal_form method
-         test compatability with existing semigroup member functions
-         add link to documentation for functions when it becomes available.
+         edit normal_form method
     '''
-
-    def __check_word(self, word):
-        '''
-        Check if word is a valid word over the alphabet of this.
-        '''
-        if not isinstance(word, str):
-            raise TypeError('the argument must be a string')
-        for letter in word:
-            if letter not in self.alphabet:
-                raise ValueError('the letter %s ' % letter
-                                 + ' does not belong to the alphabet %s'
-                                 % self.alphabet)
-
-    def __remove_brackets(self, word):
-        # pylint: disable = too-many-branches
-        if word == '':
-            return ''
-
-        #if the number of left brackets is different from the number of right
-        #brackets they can't possibly pair up
-        if not word.count('(') == word.count(')'):
-            raise ValueError('unmatched bracket')
-
-        #if the ^ is at the end of the string there is no exponent.
-        #if the ^ is at the start of the string there is no base.
-        if word[0] == '^' or word[-1] == '^':
-            raise ValueError('invalid power structure')
-
-        #checks that all ^s have an exponent.
-        for index, element in enumerate(word):
-            if element == '^':
-                if not word[index + 1] in '0123456789':
-                    raise ValueError('invalid power structure')
-
-        #i acts as a pointer to positions in the string.
-        newword = ''
-        i = 0
-        while i < len(word):
-            #if there are no brackets the character is left as it is.
-            if word[i] != '(':
-                newword += word[i]
-            else:
-                lbracket = i
-                rbracket = -1
-                #tracks how 'deep' the position of i is in terms of nested
-                #brackets
-                nestcount = 0
-                i += 1
-                while i < len(word):
-                    if word[i] == '(':
-                        nestcount += 1
-                    elif word[i] == ')':
-                        if nestcount == 0:
-                            rbracket = i
-                            break
-                        else:
-                            nestcount -= 1
-                    i += 1
-
-                #as i is always positive, if rbracket is -1 that means that
-                #the found left bracket has no corresponding right bracket.
-                #note: if this never occurs then every left bracket has a
-                #corresponding right bracket and as the number of each bracket
-                #is equal every right bracket has a corresponding left bracket
-                #and the bracket structure is valid.
-                if rbracket == -1:
-                    raise ValueError('unmatched bracket')
-
-                #if rbracket is not followed by ^ then the value inside the
-                #bracket is appended (recursion is used to remove any brackets
-                #in this value)
-                if rbracket + 1 == len(word):
-                    newword += self.__remove_brackets(word[lbracket + 1:
-                                                           rbracket])
-                elif word[rbracket + 1] != '^':
-                    newword += self.__remove_brackets(word[lbracket + 1:
-                                                           rbracket])
-                #if rbracket is followed by ^ then the value inside the
-                #bracket is appended the given number of times
-                else:
-                    i += 2
-                    while i < len(word):
-                        if word[i] in '0123456789':
-                            i += 1
-                        else:
-                            break
-                    newword += (self.__remove_brackets(word[lbracket + 1:
-                                                            rbracket])
-                                * int(word[rbracket + 2:i]))
-                    i -= 1
-            i += 1
-
-        return newword
-
-    @staticmethod
-    def __remove_powers(word):
-        if word == '':
-            return ''
-
-        #if the ^ is at the end of the string there is no exponent.
-        #if the ^ is at the start of the string there is no base.
-        if word[0] == '^' or word[-1] == '^':
-            raise ValueError('invalid power structure')
-
-        #checks that all ^s have an exponent.
-        for index, element in enumerate(word):
-            if element == '^':
-                if not word[index + 1] in '0123456789':
-                    raise ValueError('invalid power structure')
-
-        newword = ''
-        i = 0
-        while i < len(word):
-            #if last character reached there is no space for exponentiation.
-            if i == len(word) - 1:
-                newword += word[i]
-                i += 1
-            #if the character is not being powered then it is left as it is.
-            elif word[i + 1] != '^':
-                newword += word[i]
-                i += 1
-            else:
-                base_position = i
-                i += 2
-                if i < len(word):
-                    #extracts the exponent from the string.
-                    while word[i] in '0123456789':
-                        i += 1
-                        if i >= len(word):
-                            break
-                newword += (word[base_position] *
-                            int(word[base_position + 2:i]))
-        return newword
-
-    def __remove_powers_and_brackets(self, word):
-        '''
-        Removes ^ and () from a given word.
-        '''
-        return self.__remove_powers(self.__remove_brackets(word))
-
     def __init__(self, alphabet, rels):
         # Check the alphabet
         if not isinstance(alphabet, str):
@@ -197,35 +55,104 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             raise TypeError('the second argument (relations) must be a ' +
                             'list of pairs of strings')
 
-        pure_letter_alphabet = True
+        self._pure_letter_alphabet = True
         for i in alphabet:
             if not i in ('abcdefghijklmnopqrstuvwxyz1' +
                          'ABCDEFGHIJKLMNOPQRSTUVWXYZ'):
                 pure_letter_alphabet = False
                 break
 
-        if pure_letter_alphabet:
-            for i, rel in enumerate(rels):
-                for j, word in enumerate(rel):
-                    rels[i][j] = self.__remove_powers_and_brackets(word)
+        for i, rel in enumerate(rels):
+            for j, word in enumerate(rel):
+                rels[i][j] = self._parse_word(word)
 
         self.alphabet = alphabet
         self.relations = rels
 
         for rel in rels:
             for word in rel:
-                self.__check_word(word)
+                self.check_word(word)
 
         libsemigroups.FpSemigroupNC.__init__(self, len(alphabet), rels)
+        if not self.is_obviously_infinite():
+            Semigroup.__init__(self, *[FPSOME(self, i) for i in self.alphabet])
+
+    def _parse_word(self, word):
+        '''
+        Removes ^ and () from a given word.
+        '''
+        if self._pure_letter_alphabet:
+            return _remove_powers(_remove_brackets(word))
+        return word
+
+    def check_word(self, word):
+        '''
+        Check if word is a valid word over the alphabet of this.
+        '''
+        if not isinstance(word, str):
+            raise TypeError('the argument must be a string')
+        for letter in word:
+            if letter not in self.alphabet:
+                raise ValueError('the letter %s' % letter
+                                 + ' does not belong to the alphabet \'%s\''
+                                 % self.alphabet)
 
     def __repr__(self):
         return ('<fp semigroup with %d generators and %d relations>'
                 % (len(self.alphabet), len(self.relations)))
 
+    def factorisation(self, word):
+        '''
+        Factorises a given word into a list of generators each represented by
+        an integer starting at 0.
+
+        Args:
+            word (str): word to be factorised.
+
+        Returns:
+            list: factorisation into generators.
+
+        Examples:
+            >>> S = FpSemigroup('ab',[['a', 'aa'], ['b', 'bbb'], ['ab', 'ba']])
+            >>> S.factorisation('b')
+            [1]
+            >>> S.factorisation('aaabb')
+            [0, 1, 1]
+        '''
+        if self.is_obviously_infinite():
+            raise ValueError('given semigroup is infinite')
+        word = self._parse_word(word)
+        self.check_word(word)
+        Pyword = libsemigroups.PythonElementNC(FPSOME(self, word))
+        return Semigroup.factorisation(self, Pyword)
+
+    def normal_form(self, word):
+        #TODO change the way this works to not use factorisation.
+        '''
+        Converts a given word to a simple form which it is equivalent to in
+        in semigroup.
+
+        Args:
+            word (str): word to be converted.
+
+        Returns:
+            string: normal for m of the given word.
+
+        Examples:
+            >>> S = FpSemigroup('ab',[['a', 'aa'], ['b', 'bbb'], ['ab', 'ba']])
+            >>> S.normal_form('b')
+            'b'
+            >>> S.normal_form('aaabb')
+            'abb'
+            >>> S.normal_form('(a^1000)bb')
+            'abb'
+        '''
+        Factors = self.factorisation(word)
+        return ''.join(self.alphabet[i] for i in Factors)
+
     def size(self):
         '''
-        Attempts to compute the number of elements of the finitely
-        presented semigroup.
+        Computes the number of elements of the finitely presented semigroup.
 
         Returns:
             int: the size of the finitely presented semigroup.
@@ -245,23 +172,61 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             return float('inf')
         return libsemigroups.FpSemigroupNC.size(self)
 
-    def is_finite(self):
-        '''Attempts to check if a finitely presented semigroup is finite.
+    def __contains__(self, word):
+        if not isinstance(word, str):
+            raise ValueError('word should be a string')
+        word = self._parse_word(word)
+        if word == '':
+            return isinstance(self, FpMonoid)
+        for letter in word:
+            if letter not in self.alphabet:
+                return False
+        return True
+
+    def equal(self, word1, word2):
+        '''
+        Checks if 2 words in a finitely presented semigroup are equivalent.
+
+        Args:
+            word1 (str): 1st word to be compared.
+            word2 (str): 2nd word to be compared.
 
         Returns:
-            bool: ``True`` if finite, ``False`` otherwise.
+            bool: ``True`` if equivalent, ``False`` otherwise.
+
+        Examples:
+            >>> S = FpSemigroup('ab',[['a', 'aa'], ['b', 'bbb'], ['ab', 'ba']])
+            >>> S.equal('b', 'b')
+            True
+            >>> S.equal('b', 'bb')
+            False
+            >>> S.equal('a', 'aa')
+            True
+            >>> S.equal('ab', 'ba^1000')
+            True
+        '''
+        if not self.is_finite():
+            raise ValueError('given semigroup is infinite')
+        return FPSOME(self, word1) == FPSOME(self, word2)
+
+    def is_obviously_infinite(self):
+        '''Attempts to check if a finitely presented semigroup is obviously
+        infinite.
+
+        Returns:
+            bool: ``True`` if obviously infinite, ``False`` otherwise.
 
         Examples:
             >>> S = FpSemigroup('ab',
-            ...                 [['aa', 'a'],['bbb', 'ab'], ['ab','ba']])
-            >>> S.is_finite()
-            True
-            >>> FpSemigroup('ab', []).is_finite()
+            ...                 [['aa', 'a'],['bbb', 'ab'], ['ab', 'ba']])
+            >>> S.is_obviously_infinite()
             False
+            >>> FpSemigroup('ab', []).is_obviously_infinite()
+            True
         '''
         # Check if number of generators exceeds number of relations
         if len(self.relations) < len(self.alphabet):
-            return False
+            return True
 
         # Check if any generator belongs to no relation
         for letter in self.alphabet:
@@ -274,8 +239,35 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
                 if stop:
                     break
             if not stop:
-                return False
+                return True
+        return False
 
+    def enumerate(self, limit):
+        if not self.is_finite():
+            raise ValueError('given semigroup is infinite')
+        return Semigroup.enumerate(self, limit)
+
+    def nridempotents(self):
+        if not self.is_finite():
+            raise ValueError('given semigroup is infinite')
+        return Semigroup.nridempotents(self)
+
+    def is_finite(self):
+        '''Attempts to check if a finitely presented semigroup is finite.
+
+        Returns:
+            bool: ``True`` if finite, ``False`` otherwise.
+
+        Examples:
+            >>> S = FpSemigroup('ab',
+            ...                 [['aa', 'a'],['bbb', 'ab'], ['ab', 'ba']])
+            >>> S.is_finite()
+            True
+            >>> FpSemigroup('ab', []).is_finite()
+            False
+        '''
+        if self.is_obviously_infinite():
+            return False
         return isinstance(libsemigroups.FpSemigroupNC.size(self), int)
 
     def word_to_class_index(self, word):
@@ -303,7 +295,12 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             >>> S.word_to_class_index('b')
             1
         '''
-        self.__check_word(word)
+        if not self.is_finite():
+            raise ValueError('given semigroup is infinite')
+        if not isinstance(word, str):
+            raise TypeError('given word is not a string')
+        word = self._parse_word(word)
+        self.check_word(word)
         return libsemigroups.FpSemigroupNC.word_to_class_index(self, word)
 
 
@@ -346,8 +343,205 @@ class FpMonoid(FpSemigroup):
         alphabet += '1'
         FpSemigroup.__init__(self, alphabet, rels)
 
+    def is_obviously_infinite(self):
+        # Check if number of generators exceeds number of relations
+        #(adjusted to ignore identity relations)
+        if len(self.relations) + 2 < len(self.alphabet) * 3:
+            return True
+        FpSemigroup.is_obviously_infinite(self)
+
     def __repr__(self):
         nrgens = len(self.alphabet) - 1
         nrrels = len(self.relations) - 2 * nrgens - 1
         return ('<fp monoid with %d generators and %d relations>'
                 % (nrgens, nrrels))
+
+class FPSOME(libsemigroups.ElementABC):
+    '''FpSemigroupElement Object
+    Examples:
+        >>> FpS = FpSemigroup('ab',[['aa','a'],['bbb','ab'],['ab','ba']])
+        >>> FPSOME(FpS,'a')
+        'a'
+        >>> FPSOME(FpS,'bab')
+        'bab'
+    '''
+
+    def __init__(self, FpS, word):
+        '''
+        Construct an FpSemigroup element from an FpSemigroup and a string.
+
+        Args:
+            FpS (FpSemigroup):  The FpSemigroup of which the given word is
+                                an element.
+            word (string):      a string containg generators of
+                                the given semigroup.
+        Raises:
+            TypeError:  If 1st argument is not an FpSemigroup object or the
+                        second argument is not a string or a list.
+            ValueError: If the word contains a generator not n the alphabet
+                        of the given semigroup.
+        '''
+        if not isinstance(FpS, FpSemigroup):
+            raise TypeError('given Semigroup is not a valid FpSemigroup')
+        if not isinstance(word, str):
+            raise TypeError('given word must be a string')
+        self.FpS = FpS
+        self._Repword = word
+
+        if word == '':
+            if isinstance(FpS, FpMonoid):
+                self.word = '1'
+                self._Repword = '1'
+            else:
+                self.word = ''
+        else:
+            self.word = _remove_powers(_remove_brackets(word))
+
+        self.FpS.check_word(self.word)
+
+    def __eq__(self, other):
+        if not (isinstance(other, FPSOME) and
+                self.FpS is other.FpS):
+            return False
+        elif self.word == '' or other.word == '':
+            return self.word == other.word
+        return (self.word_to_class_index() ==
+                other.word_to_class_index())
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def word_to_class_index(self):
+        return self.FpS.word_to_class_index(self.word)
+
+    def __hash__(self):
+        return self.word_to_class_index()
+
+    @staticmethod
+    def degree():
+        return 0
+
+    def identity(self):
+        return FPSOME(self.FpS, '')
+
+    def __mul__(self, other):
+        if self.word == '' and other.word == '':
+            raise ValueError('no empty word in this semigroup')
+        if not (isinstance(other, FPSOME) and
+                self.FpS is other.FpS):
+            raise TypeError('given words are not members'+
+                            ' of the same FpSemigroup')
+
+        return FPSOME(self.FpS, self.word + other.word)
+
+    def __repr__(self):
+        return '\'' + self._Repword + '\''
+
+def _remove_brackets(word):
+    # pylint: disable = too-many-branches
+    if word == '':
+        return ''
+
+    #if the number of left brackets is different from the number of right
+    #brackets they can't possibly pair up
+    if not word.count('(') == word.count(')'):
+        raise ValueError('invalid bracket structue')
+
+    #if the ^ is at the end of the string there is no exponent.
+    #if the ^ is at the start of the string there is no base.
+    if word[0] == '^' or word[-1] == '^':
+        raise ValueError('invalid power structure')
+
+    #checks that all ^s have an exponent.
+    for index, element in enumerate(word):
+        if element == '^':
+            if not word[index + 1] in '0123456789':
+                raise ValueError('invalid power structure')
+
+    #i acts as a pointer to positions in the string.
+    newword = ''
+    i = 0
+    while i < len(word):
+        #if there are no brackets the character is left as it is.
+        if word[i] != '(':
+            newword += word[i]
+        else:
+            lbracket = i
+            rbracket = -1
+            #tracks how 'deep' the position of i is in terms of nested
+            #brackets
+            nestcount = 0
+            i += 1
+            while i < len(word):
+                if word[i] == '(':
+                    nestcount += 1
+                elif word[i] == ')':
+                    if nestcount == 0:
+                        rbracket = i
+                        break
+                    else:
+                        nestcount -= 1
+                i += 1
+
+            #as i is always positive, if rbracket is -1 that means that
+            #the found left bracket has no corresponding right bracket.
+            #note: if this never occurs then every left bracket has a
+            #corresponding right bracket and as the number of each bracket
+            #is equal every right bracket has a corresponding left bracket
+            #and the bracket structure is valid.
+            if rbracket == -1:
+                raise ValueError('invalid bracket structure')
+
+            #if rbracket is not followed by ^ then the value inside the
+            #bracket is appended (recursion is used to remove any brackets
+            #in this value)
+            if rbracket + 1 == len(word):
+                newword += _remove_brackets(word[lbracket + 1:
+                                                 rbracket])
+            elif word[rbracket + 1] != '^':
+                newword += _remove_brackets(word[lbracket + 1:
+                                                 rbracket])
+            #if rbracket is followed by ^ then the value inside the
+            #bracket is appended the given number of times
+            else:
+                i += 2
+                while i < len(word):
+                    if word[i] in '0123456789':
+                        i += 1
+                    else:
+                        break
+                newword += (_remove_brackets(word[lbracket + 1:
+                                                  rbracket])
+                            * int(word[rbracket + 2:i]))
+                i -= 1
+        i += 1
+
+    return newword
+
+def _remove_powers(word):
+    if word == '':
+        return ''
+
+    newword = ''
+    i = 0
+    while i < len(word):
+        #if last character reached there is no space for exponentiation.
+        if i == len(word) - 1:
+            newword += word[i]
+            i += 1
+        #if the character is not being powered then it is left as it is.
+        elif word[i + 1] != '^':
+            newword += word[i]
+            i += 1
+        else:
+            base_position = i
+            i += 2
+            if i < len(word):
+                #extracts the exponent from the string.
+                while word[i] in '0123456789':
+                    i += 1
+                    if i >= len(word):
+                        break
+            newword += (word[base_position] *
+                        int(word[base_position + 2:i]))
+    return newword

--- a/semigroups/semifp.py
+++ b/semigroups/semifp.py
@@ -6,8 +6,8 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
     A class for finitely presented semigroups.
 
     Args:
-        alphabet (list): the generators of the finitely presented semigroup,
-            must be a list of strings of length 1.
+        alphabet (string): the generators of the finitely presented semigroup,
+            must be a string of distinct characters.
 
         rels (list): the relations containing pairs of string which are
             equivalent in the finitely presented semigroup
@@ -18,7 +18,7 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
         ValueError: if TODO
 
     Examples:
-        >>> FpSemigroup(['a', 'b'],
+        >>> FpSemigroup('ab',
         ...             [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']])
         <fp semigroup with 2 generators and 3 relations>
 
@@ -43,12 +43,11 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
 
     def __init__(self, alphabet, rels):
         # Check the alphabet
-        if not isinstance(alphabet, list):
-            raise TypeError('the first argument (alphabet) must be a list')
-        elif not all(isinstance(x, str) or alphabet.count(x) > 1
-                     for x in alphabet):
+        if not isinstance(alphabet, str):
+            raise TypeError('the first argument (alphabet) must be a string')
+        elif not all(alphabet.count(x) == 1 for x in alphabet):
             raise ValueError('the first argument (alphabet) must be a '
-                             'duplicate-free list of strings')
+                             'duplicate-free string')
 
         # Corner case
         if len(alphabet) == 0 and not len(rels) == 0:
@@ -85,13 +84,13 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             int: the size of the finitely presented semigroup.
 
         Examples:
-            >>> FpSemigroup(['a', 'b'],
+            >>> FpSemigroup('ab',
             ...             [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']]).size()
             5
-            >>> FpMonoid(['a', 'b'],
+            >>> FpMonoid('ab',
             ...          [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']]).size()
             6
-            >>> FpMonoid(['a', 'b'],
+            >>> FpMonoid('ab',
             ...          [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']]).size()
             6
         '''
@@ -106,11 +105,11 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             bool: ``True`` if finite, ``False`` otherwise.
 
         Examples:
-            >>> S = FpSemigroup(['a', 'b'],
+            >>> S = FpSemigroup('ab',
             ...                 [['aa', 'a'],['bbb', 'ab'], ['ab','ba']])
             >>> S.is_finite()
             True
-            >>> FpSemigroup(['a', 'b'], []).is_finite()
+            >>> FpSemigroup('ab', []).is_finite()
             False
         '''
         # Check if number of generators exceeds number of relations
@@ -119,6 +118,7 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
 
         # Check if any generator belongs to no relation
         for letter in self.alphabet:
+            stop = False
             for rel in self.relations:
                 for word in rel:
                     if letter in word:
@@ -126,7 +126,7 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
                         break
                 if stop:
                     break
-            else:
+            if not stop:
                 return False
 
         return (isinstance(libsemigroups.FpSemigroupNC.size(self), int) or
@@ -146,7 +146,7 @@ class FpSemigroup(libsemigroups.FpSemigroupNC):
             ValueError: if TODO
 
         Examples:
-            >>> S = FpSemigroup(['a', 'b'],
+            >>> S = FpSemigroup('ab',
             ...                 [['aa', 'a'], ['bbb', 'ab'], ['ab', 'ba']])
             >>> S.word_to_class_index('a')
             0
@@ -171,7 +171,7 @@ class FpMonoid(FpSemigroup):
         for letter in alphabet:
             rels.append([letter + '1', letter])
             rels.append(['1' + letter, letter])
-        alphabet.append('1')
+        alphabet += '1'
         FpSemigroup.__init__(self, alphabet, rels)
 
     def __repr__(self):

--- a/semigroups/semigrp.py
+++ b/semigroups/semigrp.py
@@ -1,7 +1,7 @@
 '''
 This module contains classes for representing semigroups.
 '''
-# pylint: disable = no-member, protected-access, invalid-name,
+# pylint: disable = no-member, protected-access, invalid-name
 
 import libsemigroups
 from semigroups.elements import Transformation
@@ -26,10 +26,10 @@ class Semigroup(libsemigroups.SemigroupNC):
         elif len(args) == 0:
             ValueError('there must be at least 1 argument')
 
-        gens = [g if isinstance(g, ElementABC) else PythonElementNC(g)
-                for g in args]
+        gens = [g if (isinstance(g, ElementABC) and str(type(g)) !=
+                      "<class 'semigroups.semifp.FPSOME'>")
+                else PythonElementNC(g) for g in args]
         libsemigroups.SemigroupNC.__init__(self, gens)
-
 
 def FullTransformationMonoid(n):
     '''

--- a/tests/test_semifp.py
+++ b/tests/test_semifp.py
@@ -19,7 +19,9 @@ class TestFpSemigroup(unittest.TestCase):
             FpSemigroup('aa',[])
         FpSemigroup('a', [])
         FpSemigroup('a', [['a', 'aa']])
-        FpSemigroup('ab', [['b', 'aa']])
+        FpSemigroup('ab', [['b', 'a(a)']])
+        FpSemigroup('a', [['a', 'a^4']])
+        FpSemigroup('ab', [['b', '(ab)^2a']])
 
     def test_alphabet_str(self):
         with self.assertRaises(ValueError):
@@ -93,6 +95,8 @@ class TestFpMonoid(unittest.TestCase):
         FpMonoid("a", [["a", "aa"]])
         FpMonoid("ab", [["b", "aa"]])
         FpMonoid("ab", [["1", "aa"]])
+        FpMonoid("ab", [["b", "a^2"]])
+        FpMonoid("ab", [["1", "(a)^6"]])
 
     def test_alphabet_str(self):
         with self.assertRaises(ValueError):

--- a/tests/test_semifp.py
+++ b/tests/test_semifp.py
@@ -13,45 +13,59 @@ del path
 class TestFpSemigroup(unittest.TestCase):
 
     def test_valid_init(self):
-        FpSemigroup(['a'], [])
-        FpSemigroup(['a'], [['a', 'aa']])
-        FpSemigroup(['a', 'b'], [['b', 'aa']])
+        with self.assertRaises(TypeError):
+            FpSemigroup(['a'],[])
+        with self.assertRaises(ValueError):
+            FpSemigroup('aa',[])
+        FpSemigroup('a', [])
+        FpSemigroup('a', [['a', 'aa']])
+        FpSemigroup('ab', [['b', 'aa']])
 
     def test_alphabet_str(self):
         with self.assertRaises(ValueError):
-            FpSemigroup([], [['a', 'aa']])
+            FpSemigroup('', [['a', 'aa']])
         with self.assertRaises(ValueError):
-            FpSemigroup(['a'], [['b', 'aa']])
+            FpSemigroup('a', [['b', 'aa']])
         with self.assertRaises(ValueError):
-            FpSemigroup(['a', 'a'], [['b', 'aa']])
+            FpSemigroup('aa', [['b', 'aa']])
 
     def test_rels_str(self):
         with self.assertRaises(TypeError):
-            FpSemigroup(["a", "b"], "[\"a\", \"aa\"]")
+            FpSemigroup("ab", "[\"a\", \"aa\"]")
         with self.assertRaises(TypeError):
-            FpSemigroup(["a", "b"], ["\"b", "aa\""])
+            FpSemigroup("ab", ["\"b", "aa\""])
         with self.assertRaises(TypeError):
-            FpSemigroup(["a", "b"], [["a", "aa", "b"]])
+            FpSemigroup("ab", [["a", "aa", "b"]])
         with self.assertRaises(TypeError):
-            FpSemigroup(["a", "b"], [["b", ["a", "a"]]])
+            FpSemigroup("ab", [["b", ["a", "a"]]])
         with self.assertRaises(ValueError):
-            FpSemigroup(["a", "b"], [["b", "ca"]])
+            FpSemigroup("ab", [["b", "ca"]])
 
     def test_set_report_str(self):
-        S = FpSemigroup(["a"], [["a", "aa"]])
+        S = FpSemigroup("a", [["a", "aa"]])
         S.set_report(True)
         S.set_report(False)
         with self.assertRaises(TypeError):
             S.set_report("False")
 
+    def test_is_finite_str(self):
+        S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
+        self.assertEqual(S.is_finite(), True)
+        S = FpSemigroup("ab", [])
+        self.assertEqual(S.is_finite(), False)
+        S = FpSemigroup("ab", [["a","a"],["a","a"]])
+        self.assertEqual(S.is_finite(), False)
+
     def test_size_str(self):
-        S = FpSemigroup(["a"], [["a", "aa"]])
+        S = FpSemigroup("a", [["a", "aa"]])
         self.assertEqual(S.size(), 1)
-        S = FpSemigroup(["a", "b"], [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
+        S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
         self.assertEqual(S.size(), 3)
+        S = FpSemigroup("ab", [])
+        self.assertEqual(S.size(), float("inf"))
 
     def test_word_to_class_index_str(self):
-        S = FpSemigroup(["a", "b"], [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
+        S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
 
         self.assertIsInstance(S.word_to_class_index("aba"), int)
 
@@ -65,53 +79,55 @@ class TestFpSemigroup(unittest.TestCase):
                          S.word_to_class_index("abaaabb"))
 
     def test_repr(self):
-        S = FpSemigroup(["a", "b"], [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
+        S = FpSemigroup("ab", [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
         self.assertEqual(S.__repr__(),
                          "<fp semigroup with 2 generators and 3 relations>")
 
 class TestFpMonoid(unittest.TestCase):
 
     def test_valid_init(self):
-        FpMonoid([], [])
-        FpMonoid(["a"], [])
-        FpMonoid(["a"], [["a", "aa"]])
-        FpMonoid(["a", "b"], [["b", "aa"]])
-        FpMonoid(["a", "b"], [["1", "aa"]])
+        FpMonoid("", [])
+        FpMonoid("a", [])
+        with self.assertRaises(ValueError):
+            FpMonoid("1", [])
+        FpMonoid("a", [["a", "aa"]])
+        FpMonoid("ab", [["b", "aa"]])
+        FpMonoid("ab", [["1", "aa"]])
 
     def test_alphabet_str(self):
         with self.assertRaises(ValueError):
-            FpMonoid([], [["a", "aa"]])
+            FpMonoid("", [["a", "aa"]])
         with self.assertRaises(ValueError):
-            FpMonoid(["a"], [["b", "aa"]])
+            FpMonoid("a", [["b", "aa"]])
         with self.assertRaises(ValueError):
-            FpMonoid(["a", "a"], [["b", "aa"]])
+            FpMonoid("aa", [["b", "aa"]])
 
     def test_rels_str(self):
         with self.assertRaises(TypeError):
-            FpMonoid(["a", "b"], "[\"a\", \"aa\"]")
+            FpMonoid("ab", "[\"a\", \"aa\"]")
         with self.assertRaises(TypeError):
-            FpMonoid(["a", "b"], ["\"b\", \"aa\""])
+            FpMonoid("ab", ["\"b\", \"aa\""])
         with self.assertRaises(TypeError):
-            FpMonoid(["a", "b"], [["a", "aa", "b"]])
+            FpMonoid("ab", [["a", "aa", "b"]])
         with self.assertRaises(TypeError):
-            FpMonoid(["a", "b"], [["b", ["a", "a"]]])
+            FpMonoid("ab", [["b", ["a", "a"]]])
         with self.assertRaises(ValueError):
-            FpMonoid(["a", "b"], [["b", "ca"]])
+            FpMonoid("ab", [["b", "ca"]])
 
     def test_set_report_str(self):
-        M = FpMonoid(["a"], [["a", "aa"]])
+        M = FpMonoid("a", [["a", "aa"]])
         M.set_report(True)
         M.set_report(False)
         with self.assertRaises(TypeError):
             M.set_report("False")
 
     def test_size(self):
-        self.assertEqual(FpMonoid(["a"], [["a", "aa"]]).size(), 2)
-        self.assertEqual(FpMonoid(["a", "b"], [["a", "aa"], ["b", "bb"],
+        self.assertEqual(FpMonoid("a", [["a", "aa"]]).size(), 2)
+        self.assertEqual(FpMonoid("ab", [["a", "aa"], ["b", "bb"],
         ["ab", "ba"]]).size(), 4)
 
     def test_word_to_class_index_str(self):
-        M = FpMonoid(["a", "b"], [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
+        M = FpMonoid("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
         self.assertEqual(M.word_to_class_index('a'),
                          M.word_to_class_index('aa'))
         self.assertNotEqual(M.word_to_class_index('a'),
@@ -120,7 +136,7 @@ class TestFpMonoid(unittest.TestCase):
         self.assertIsInstance(M.word_to_class_index('aba'), int)
 
     def test_repr(self):
-        M = FpMonoid(["a", "b"], [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
+        M = FpMonoid("ab", [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
         self.assertEqual(M.__repr__(),
                          "<fp monoid with 2 generators and 3 relations>")
 

--- a/tests/test_semifp.py
+++ b/tests/test_semifp.py
@@ -2,28 +2,50 @@
 import unittest
 import sys
 import os
-from semigroups import FpSemigroup, FpMonoid
+from semigroups import FpSemigroup, FpMonoid, FPSOME
 
 path = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if path not in sys.path:
     sys.path.insert(1, path)
 del path
 
-
 class TestFpSemigroup(unittest.TestCase):
-
     def test_valid_init(self):
         with self.assertRaises(TypeError):
             FpSemigroup(['a'],[])
         with self.assertRaises(ValueError):
             FpSemigroup('aa',[])
+        with self.assertRaises(TypeError):
+            FpSemigroup('a', []).check_word({})
         FpSemigroup('a', [])
+        FpSemigroup('~', [])
         FpSemigroup('a', [['a', 'aa']])
         FpSemigroup('ab', [['b', 'a(a)']])
         FpSemigroup('a', [['a', 'a^4']])
         FpSemigroup('ab', [['b', '(ab)^2a']])
 
-    def test_alphabet_str(self):
+    def test_parse_word(self):
+        S = FpSemigroup('~', [])
+        self.assertEqual(S._parse_word("~"),"~")
+        S = FpSemigroup('a', [])
+        self.assertEqual(S._parse_word("aa"),"aa")
+        self.assertEqual(S._parse_word("()(()())"),"")
+        self.assertEqual(S._parse_word("ba^10b"),"baaaaaaaaaab")
+        self.assertEqual(S._parse_word("((b)a)^3b"),"bababab")
+        with self.assertRaises(ValueError):
+            S._parse_word(")(")
+        with self.assertRaises(ValueError):
+            S._parse_word("(((b)^2(a))))")
+        with self.assertRaises(ValueError):
+            S._parse_word("(((b)^2)))((((a))(b))")
+        with self.assertRaises(ValueError):
+            S._parse_word("^2")
+        with self.assertRaises(ValueError):
+            S._parse_word("a^")
+        with self.assertRaises(ValueError):
+            S._parse_word("a^a")
+
+    def test_alphabet(self):
         with self.assertRaises(ValueError):
             FpSemigroup('', [['a', 'aa']])
         with self.assertRaises(ValueError):
@@ -31,7 +53,7 @@ class TestFpSemigroup(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpSemigroup('aa', [['b', 'aa']])
 
-    def test_rels_str(self):
+    def test_rels(self):
         with self.assertRaises(TypeError):
             FpSemigroup("ab", "[\"a\", \"aa\"]")
         with self.assertRaises(TypeError):
@@ -43,14 +65,14 @@ class TestFpSemigroup(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpSemigroup("ab", [["b", "ca"]])
 
-    def test_set_report_str(self):
+    def test_set_report(self):
         S = FpSemigroup("a", [["a", "aa"]])
         S.set_report(True)
         S.set_report(False)
         with self.assertRaises(TypeError):
             S.set_report("False")
 
-    def test_is_finite_str(self):
+    def test_is_finite(self):
         S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
         self.assertEqual(S.is_finite(), True)
         S = FpSemigroup("ab", [])
@@ -58,7 +80,7 @@ class TestFpSemigroup(unittest.TestCase):
         S = FpSemigroup("ab", [["a","a"],["a","a"]])
         self.assertEqual(S.is_finite(), False)
 
-    def test_size_str(self):
+    def test_size(self):
         S = FpSemigroup("a", [["a", "aa"]])
         self.assertEqual(S.size(), 1)
         S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
@@ -66,19 +88,67 @@ class TestFpSemigroup(unittest.TestCase):
         S = FpSemigroup("ab", [])
         self.assertEqual(S.size(), float("inf"))
 
-    def test_word_to_class_index_str(self):
+    def test_normal_form(self):
+        S = FpSemigroup("a", [["a", "aa"]])
+        self.assertEqual(S.normal_form("a^1000"), "a")
+        S = FpMonoid("a", [["a", "aa"]])
+        self.assertEqual(S.normal_form("a^0"), "1")
+        S = FpSemigroup("ab", [["a", "aaa"], ["b", "bb"], ["ab", "ba"]])
+        self.assertEqual(S.normal_form("(ba)^10"), "aab")
+
+    def test_word_to_class_index(self):
         S = FpSemigroup("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
-
         self.assertIsInstance(S.word_to_class_index("aba"), int)
-
         with self.assertRaises(TypeError):
             S.word_to_class_index([1, "0"])
-
         with self.assertRaises(TypeError):
             S.word_to_class_index(["aba"])
-
         self.assertEqual(S.word_to_class_index("aba"),
-                         S.word_to_class_index("abaaabb"))
+                        S.word_to_class_index("abaaabb"))
+        S = FpSemigroup("ab",[])
+        with self.assertRaises(ValueError):
+            S.word_to_class_index("aba")
+
+    def test_equal(self):
+        S = FpSemigroup("ab",[["a", "a^5"],["b","bb"],["ab","ba"]])
+        self.assertTrue(S.equal("a","a^5"))
+        self.assertTrue(S.equal("a","aaaaa"))
+        self.assertTrue(S.equal("abb","ba"))
+        self.assertTrue(S.equal("ab","((a)^3b)^167"))
+        S = FpSemigroup("ab",[])
+        with self.assertRaises(ValueError):
+            S.equal("a", "b")
+
+    def test_contains(self):
+        FpS = FpSemigroup("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
+        with self.assertRaises(ValueError):
+            1 in FpS
+        self.assertTrue("abb" in FpS)
+        self.assertFalse("c" in FpS)
+        self.assertFalse("" in FpS)
+
+    def test_enumerate(self):
+        S = FpSemigroup("ab",[["a", "a^5"],["b","bb"],["ab","ba"]])
+        S.enumerate(73)
+        S = FpSemigroup("ab",[])
+        with self.assertRaises(ValueError):
+            S.enumerate(73)
+
+    def test_nridempotents(self):
+        S = FpSemigroup("ab",[["a", "a^5"],["b","bb"],["ab","ba"]])
+        self.assertEqual(S.nridempotents(),3)
+        S = FpMonoid("ab",[["a", "a^5"], ["b","bb"], ["ab","ba"]])
+        self.assertEqual(S.nridempotents(),4)
+        S = FpSemigroup("ab",[])
+        with self.assertRaises(ValueError):
+            S.nridempotents()
+
+    def test_factorisation(self):
+        S = FpSemigroup("ab",[["a", "a^5"],["b","bb"],["ab","ba"]])
+        self.assertEqual(S.factorisation("aba"),[0, 0, 1])
+        S = FpSemigroup("ab",[])
+        with self.assertRaises(ValueError):
+            S.factorisation("aba")
 
     def test_repr(self):
         S = FpSemigroup("ab", [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
@@ -98,7 +168,7 @@ class TestFpMonoid(unittest.TestCase):
         FpMonoid("ab", [["b", "a^2"]])
         FpMonoid("ab", [["1", "(a)^6"]])
 
-    def test_alphabet_str(self):
+    def test_alphabet(self):
         with self.assertRaises(ValueError):
             FpMonoid("", [["a", "aa"]])
         with self.assertRaises(ValueError):
@@ -106,7 +176,7 @@ class TestFpMonoid(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpMonoid("aa", [["b", "aa"]])
 
-    def test_rels_str(self):
+    def test_rels(self):
         with self.assertRaises(TypeError):
             FpMonoid("ab", "[\"a\", \"aa\"]")
         with self.assertRaises(TypeError):
@@ -118,31 +188,113 @@ class TestFpMonoid(unittest.TestCase):
         with self.assertRaises(ValueError):
             FpMonoid("ab", [["b", "ca"]])
 
-    def test_set_report_str(self):
+    def test_contains(self):
+        FpM = FpMonoid("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
+        with self.assertRaises(ValueError):
+            1 in FpM
+        self.assertTrue("abb" in FpM)
+        self.assertTrue("" in FpM)
+
+    def test_set_report(self):
         M = FpMonoid("a", [["a", "aa"]])
         M.set_report(True)
         M.set_report(False)
         with self.assertRaises(TypeError):
             M.set_report("False")
 
+    def test_current_max_word_length(self):
+        S = FpSemigroup("ab",[["a", "a^5"],["b","bb"],["ab","ba"]])
+        S.current_max_word_length()
+
     def test_size(self):
         self.assertEqual(FpMonoid("a", [["a", "aa"]]).size(), 2)
         self.assertEqual(FpMonoid("ab", [["a", "aa"], ["b", "bb"],
         ["ab", "ba"]]).size(), 4)
 
-    def test_word_to_class_index_str(self):
+    def test_word_to_class_index(self):
         M = FpMonoid("ab", [["a", "aa"], ["b", "bb"], ["ab", "ba"]])
         self.assertEqual(M.word_to_class_index('a'),
                          M.word_to_class_index('aa'))
         self.assertNotEqual(M.word_to_class_index('a'),
                             M.word_to_class_index('bb'))
-
         self.assertIsInstance(M.word_to_class_index('aba'), int)
 
     def test_repr(self):
         M = FpMonoid("ab", [["aa", "a"], ["bbb", "ab"], ["ab", "ba"]])
         self.assertEqual(M.__repr__(),
                          "<fp monoid with 2 generators and 3 relations>")
+
+class TestFPSOME(unittest.TestCase):
+
+    def test_valid_init(self):
+        FpS = FpSemigroup("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
+        FPSOME(FpS,"aba")
+        FPSOME(FpS,"a")
+        FpS = FpSemigroup("mo", [["ooo", "o"]])
+        FPSOME(FpS, "moo")
+        FPSOME(FpS, "ooo")
+        FpS = FpSemigroup("cowie", [])
+        FPSOME(FpS,"cowie")
+        FpS2 = FpSemigroup('~', [])
+        FPSOME(FpS2,"~~")
+        with self.assertRaises(TypeError):
+            FPSOME("aba", "aba")
+        with self.assertRaises(TypeError):
+            FPSOME(FpS, FpS)
+        with self.assertRaises(ValueError):
+            FPSOME(FpS,"abc")
+
+    def test_eq_(self):
+        FpS = FpSemigroup("ab", [["a^10", "a"], ["bbb", "b"], ["ba", "ab"]])
+        a = FPSOME(FpS, "aba")
+        b = a
+        self.assertEqual(a, b)
+        a = FPSOME(FpS, "aaba")
+        b = FPSOME(FpS, "ba^3")
+        self.assertEqual(a, b)
+        a = FPSOME(FpS, "")
+        self.assertEqual(a, a)
+
+    def test_ne_(self):
+        FpS = FpSemigroup("ab", [["a^10", "a"], ["bbb", "b"], ["ba", "ab"]])
+        a = FPSOME(FpS, "aba")
+        b = a * a
+        self.assertNotEqual(a, b)
+        a = FPSOME(FpS, "aaba")
+        b = FPSOME(FpS, "ba^4")
+        self.assertNotEqual(a, b)
+
+    def test_identity(self):
+        FpS = FpSemigroup("ab", [["a^10", "a"], ["bbb", "b"], ["ba", "ab"]])
+        a = FPSOME(FpS, "aba")
+        self.assertEqual(a.identity(), FPSOME(FpS, ""))
+        FpS = FpMonoid("ab", [["a^10", "a"], ["bbb", "b"], ["ba", "ab"]])
+        a = FPSOME(FpS, "aba")
+        self.assertEqual(a.identity(), FPSOME(FpS, ""))
+
+    def test_degree(self):
+        FpS = FpSemigroup("ab", [["a^10", "a"], ["bbb", "b"], ["ba", "ab"]])
+        a = FPSOME(FpS, "aba")
+        self.assertEqual(a.degree(), 0)
+
+    def test_mul(self):
+        FpS = FpSemigroup("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
+        other = "aa"
+        a = FPSOME(FpS, "aba")
+        a * a
+        e = FPSOME(FpS, "")
+        self.assertEqual(a * a, FPSOME(FpS, "abaaba"))
+        with self.assertRaises(ValueError):
+            e * e
+        with self.assertRaises(TypeError):
+            a * other
+        with self.assertRaises(TypeError):
+            FPSOME(FpSemigroup("ab", []), "aba") * a
+        
+    def test_repr(self):
+        FpS = FpSemigroup("ab", [["aa", "a"], ["bbb", "b"], ["ab", "ba"]])
+        self.assertEqual(FPSOME(FpS, "ab").__repr__(), "'ab'")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR includes the following:
* changes the input of `FpSemigroup` from a list of strings to a single string
* expands test coverage for `fpsemi.py` so that every line is checked
* fixes linting problems
* adds function to deal with brackets and powers when they are used in input of relations
* makes `FpSemigroup` a subclass of `Semigroup` and adds the `FPSOME` (Finitely Presented Semigroup Or Monoid Element) class