### PR TITLE
semifp: fixes fpsemigroup containment

### DIFF
--- a/semigroups/semifp.py
+++ b/semigroups/semifp.py
@@ -177,7 +177,7 @@ class FpSemigroup(libsemigroups.FpSemigroupNC, Semigroup):
             if isinstance(word.get_value(), _FPSOME):
                 return word.get_value().FpS == self
         if not isinstance(word, str):
-            raise ValueError('word should be a string')
+            return False
         word = self._parse_word(word)
         if word == '':
             return isinstance(self, FpMonoid)

--- a/tests/test_semifp.py
+++ b/tests/test_semifp.py
@@ -122,8 +122,7 @@ class TestFpSemigroup(unittest.TestCase):
 
     def test_contains(self):
         FpS = FpSemigroup("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
-        with self.assertRaises(ValueError):
-            1 in FpS
+        self.assertFalse(1 in FpS)
         self.assertTrue("abb" in FpS)
         self.assertFalse("c" in FpS)
         self.assertFalse("" in FpS)
@@ -191,8 +190,7 @@ class TestFpMonoid(unittest.TestCase):
 
     def test_contains(self):
         FpM = FpMonoid("ab", [["aa", "a"], ["bbb", "b"], ["ba", "ab"]])
-        with self.assertRaises(ValueError):
-            1 in FpM
+        self.assertFalse(1 in FpM)
         self.assertTrue("abb" in FpM)
         self.assertTrue("" in FpM)
 


### PR DESCRIPTION
previously raised ValueError when input was the wrong type,
now returns False